### PR TITLE
Delete reset styles from index.css

### DIFF
--- a/src/components/HostSummary/HostSummary.module.css
+++ b/src/components/HostSummary/HostSummary.module.css
@@ -29,15 +29,18 @@
 .hostDetails {
   display: flex;
   flex-direction: column;
+  gap: 4px;
 }
 
 .hostedBy {
   font-weight: 500;
   font-size: 16px;
   color: var(--primary);
+  margin: 0;
 }
 
 .hostingDuration {
   color: var(--neutral);
   font-size: 14px;
+  margin: 0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13,12 +13,6 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 a {
   font-weight: 500;
   color: #646cff;


### PR DESCRIPTION
After adding reset css styles to reset default padding and margin in the index.css I realized that it broke some other components that use paragraphs and <h1..h6>. I decided that was a bad idea to change global styles during the development. So, I removed them from index.css. 