### PR TITLE
Add end point to Filter by Search

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,10 +9,12 @@ app.use(cors());
 // import Routes
 const placesRoutes = require('./routes/places');
 const destinationsRoutes = require('./routes/destinations');
+const searchedPlacesRoutes = require('./routes/searchedPlaces');
 
 // Use Routes
 app.use('/places', placesRoutes); 
 app.use('/destinations', destinationsRoutes); 
+app.use('/s', searchedPlacesRoutes);
 
 app.listen(PORT, (error) => {
   if (error)

--- a/server/routes/searchedPlaces.js
+++ b/server/routes/searchedPlaces.js
@@ -9,13 +9,11 @@ router.get("/:destination/homes", (req, res) => {
 	const filteredResult = [];
 
 	const filteredDestinations = destination ? places.filter(place => place.destination === destination && place.guests >= guests) : places;
-	console.log(checkIn);
 	if (filteredDestinations.length)
 	{
 		filteredDestinations.forEach(destination => {
 			let isPlaceNotAvailable = destination.reservations.some((reservation)=> {
 				const [reservationCheckIn, reservationCheckOut] = reservation.dates;
-				console.log(reservationCheckIn === checkIn ? "true" : "false");
 				return ((reservationCheckIn <= checkIn && reservationCheckOut > checkIn) ||
 					(reservationCheckIn < checkOut && reservationCheckOut >= checkOut) ||
 					reservationCheckIn === checkIn ||

--- a/server/routes/searchedPlaces.js
+++ b/server/routes/searchedPlaces.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const places = require("../src/data/places.json");
+
+const router = express.Router();
+
+router.get("/:destination/homes", (req, res) => {
+	const {destination} = req.params;
+	const {checkIn, checkOut, guests = 1} = req.query;
+	const filteredResult = [];
+
+	const filteredDestinations = destination ? places.filter(place => place.destination === destination && place.guests >= guests) : places;
+	console.log(checkIn);
+	if (filteredDestinations.length)
+	{
+		filteredDestinations.forEach(destination => {
+			let isPlaceNotAvailable = destination.reservations.some((reservation)=> {
+				const [reservationCheckIn, reservationCheckOut] = reservation.dates;
+				console.log(reservationCheckIn === checkIn ? "true" : "false");
+				return ((reservationCheckIn <= checkIn && reservationCheckOut > checkIn) ||
+					(reservationCheckIn < checkOut && reservationCheckOut >= checkOut) ||
+					reservationCheckIn === checkIn ||
+					reservationCheckOut === checkOut)
+			})
+			if (isPlaceNotAvailable == false)
+				filteredResult.push(destination);
+		})
+	}
+    res.json(filteredResult);
+  });
+
+module.exports = router;

--- a/server/src/data/places.json
+++ b/server/src/data/places.json
@@ -4,33 +4,93 @@
       "title": "Idyllic house by the sea",
       "host": "Hosted by Wendy and Elisa",
       "price": "Coming soon",
-      "image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720"
+      "image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720",
+	  "destination": "US",
+	  "guests": 1,
+	  "reservations": [
+		{
+			"reservationId": 1,
+			"customerId": 1,
+			"dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 04 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+		},
+		{
+			"reservationId": 2,
+			"customerId": 2,
+			"dates": ["Tue Dec 06 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 07 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+		}
+	  ]
     },
     {
       "id": 2,
       "title": "Studio Zempow / ecological wooden house / photo studio",
 	  "host": "Hosted by Wendy and Elisa",
       "price": "Coming soon",
-      "image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720"
+      "image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720",
+	  "destination": "US",
+	  "guests": 2,
+	  "reservations": [
+		{
+			"reservationId": 1,
+			"customerId": 3,
+			"dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 10 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+		},
+		{
+			"reservationId": 2,
+			"customerId": 4,
+			"dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 19 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+		}
+	  ]
     },
     {
 	"id": 3,
 	"title": "Funen's best ocean view",
 	"host": "Hosted by Wendy and Elisa",
 	"price": "Coming soon",
-	"image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720"
+	"image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720",
+	"destination": "Spain",
+	"guests": 3,
+	"reservations": [
+	  {
+		  "reservationId": 1,
+		  "customerId": 5,
+		  "dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 15 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+	  }
+	]
 	},
     {
 	"id": 4,
 	"title": "Cozy Apartment in City Center",
 	"host": "Hosted by Wendy and Elisa",
 	"price": "Coming soon",
-	"image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720"
+	"image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720",
+	"destination": "Italy",
+	"guests": 1,
+	"reservations": [
+	  {
+		  "reservationId": 1,
+		  "customerId": 6,
+		  "dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+	  }
+	]
 	},
     {
 	"title": "House at a beach" ,
 	"host": "Hosted by Wendy and Elisa",
 	"price": "Coming soon",
-	"image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720"
+	"image": "https://a0.muscache.com/im/pictures/miso/Hosting-44280804/original/8de614aa-28b4-45af-8b4b-266c917f0efd.jpeg?im_w=720",
+	"destination": "US",
+	"guests": 3,
+	"reservations": [
+	  {
+		  "reservationId": 1,
+		  "customerId": 7,
+		  "dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+	  },
+	  {
+		  "reservationId": 2,
+		  "customerId": 8,
+		  "dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+	  }
+	]
 	}
   ]

--- a/server/src/data/places.json
+++ b/server/src/data/places.json
@@ -84,12 +84,12 @@
 	  {
 		  "reservationId": 1,
 		  "customerId": 7,
-		  "dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+		  "dates": ["Tue Dec 01 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 04 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
 	  },
 	  {
 		  "reservationId": 2,
 		  "customerId": 8,
-		  "dates": ["Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 03 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
+		  "dates": ["Tue Dec 04 2024 00:00:00 GMT+0100 (Central European Standard Time)", "Tue Dec 06 2024 00:00:00 GMT+0100 (Central European Standard Time)"]
 	  }
 	]
 	}

--- a/src/components/SearchPanel/SearchPanel.jsx
+++ b/src/components/SearchPanel/SearchPanel.jsx
@@ -3,15 +3,32 @@ import SearchBar from "../SearchBar/SearchBar";
 import ToggleButtonsStaysExperiences from '../ToggleButtonsStaysExperiences/ToggleButtonsStaysExperiences'
 import styles from "./SearchPanel.module.css"
 import { useState } from 'react';
+import { createSearchParams, useNavigate } from 'react-router-dom';
 
 const SearchPanel = () => {
 
     const [searchType, setSearchType] = useState("stays");
+    const navigate = useNavigate();
+
     const toggleSearchType = (type) => {
         setSearchType(type);
     };
-    const handleAirbnbSearch = ({ location, checkIn, checkOut, guests }) => {
-        // Logic for home search
+    const handleAirbnbSearch = ({ location: destination, checkIn, checkOut, guests }) => {
+        // TODO: After configuring the props below should be removed. USED FOR TESTING.
+        destination = "US";
+        checkIn = new Date(2024, 11, 2);
+        checkOut = new Date(2024, 11, 3);
+        guests = 1;
+        ///////////////////
+
+        const searchQueries = {
+            destination,
+            checkIn,
+            checkOut,
+            guests
+        }
+        if (destination)
+            navigate({pathname: `/s/${destination}/homes`, search: createSearchParams(searchQueries).toString()});
     };
 
     return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,6 +9,7 @@ import ErrorPage from "./error-page";
 import './index.css';
 import ProductPage from './pages/ProductPage.jsx';
 import Root from './pages/RootLayout/Root.jsx';
+import FilteredPlacesPage from './pages/FilteredPlacesPage/FilteredPlacesPage.jsx';
 
 
 
@@ -26,6 +27,10 @@ const router = createBrowserRouter([
       {
         path: "rooms/:productId",
         element: <ProductPage/>,
+      },
+      {
+        path: "s/:destination/homes",
+        element: <FilteredPlacesPage/>,
       },
     ]
   },

--- a/src/pages/FilteredPlacesPage/FilteredPlacesPage.jsx
+++ b/src/pages/FilteredPlacesPage/FilteredPlacesPage.jsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from "react";
+import ProductCard from "../../components/ProductCard/ProductCard";
+import { BASE_URL } from "../../constants/constants";
+import axios from "axios";
+import { useParams, useSearchParams } from "react-router-dom";
+
+const FilteredPlacesPage = () => {
+	const [filteredPlaces, setFilteredPlaces] = useState([]);
+	const {destination} = useParams();
+	const [searchParams] = useSearchParams();
+
+	useEffect(()=> {
+	axios.get(`${BASE_URL}s/${destination}/homes`, {
+		params: searchParams
+	})
+	.then(response => setFilteredPlaces(response?.data))
+	.catch(error => console.error(`Something went wrong. ${error.message}.`))
+	}, [destination, searchParams])
+	
+	return (
+		<div>
+			{
+				filteredPlaces.map((filteredPlace, id) => {
+					return (
+						<ProductCard
+						key={id}
+						images={[filteredPlace.image]}
+						title={filteredPlace.title}
+						host={filteredPlace.host}
+						price={filteredPlace.price}
+					  />
+					)
+				})
+			}
+		</div>
+	)
+}
+
+export default FilteredPlacesPage;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/82c167f7-186c-41f3-80cd-7d55c1c19454)

In this ticket I have created an end point to get the filtered places for search.
In order to complete the task several data with related to reservation is added to the dummy places.json file.
The results are shown in a different page eg: http://localhost:5173/s/US/homes.

Since the search panel is not able to take inputs dynamically for testing purposes one test case is hard coded.
