### PR TITLE
Fix conflict between dropdowns in the header section and calendar tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,6 @@ import ProductCard from "./components/ProductCard/ProductCard";
 import CalendarToggle from "./components/calendarToggle/CalendarToggle";
 import axios from "axios";
 import { BASE_URL } from "./constants/constants";
-import DataIncrementsButtonForTheCalendar from "./components/DataIncrementsButtonForTheCalendar/DataIncrementsButtonForTheCalendar";
 import CategoryTabs from "./components/CategoryTabs/CategoryTabs";
 
 function App() {
@@ -39,8 +38,7 @@ function App() {
         <CalendarToggle />
       </div>
       
-      <DataIncrementsButtonForTheCalendar />
-<CategoryTabs />  
+      <CategoryTabs />  
 
       <div className="grid">
         {places.map((place) => {

--- a/src/components/CategoryTabs/CategoryTabs.module.css
+++ b/src/components/CategoryTabs/CategoryTabs.module.css
@@ -5,6 +5,7 @@
   margin: 0 auto;
   background-color: white;
   z-index: 1000;
+  margin-top: 32px;
 }
 
 .categoryTabsWrapper {

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,7 +1,7 @@
 .headerSectionContainer {
     width: 100%;
     position: relative;
-    z-index: 1000;
+    z-index: 1111;
 }
 
 .header {


### PR DESCRIPTION
I have fixed conflict between dropdowns in the header section and calendar tabs by adding bigger z-index to the Header and adding margin-top to the CalendarTab.

![fixed-conflict](https://github.com/user-attachments/assets/71e536ce-2d1e-45de-ae72-72b8a4659c5e)
 