### PR TITLE
Fix placing of CategoryTabs on small devices and fix grid margin-bottom

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,7 +18,7 @@
   width: 95vw;
   overflow: hidden;
   justify-content: center;
-  padding-bottom: 5rem;
+  padding-bottom: 1rem;
 }
 
 .title {

--- a/src/components/CategoryTabs/CategoryTabs.module.css
+++ b/src/components/CategoryTabs/CategoryTabs.module.css
@@ -183,6 +183,7 @@
     max-width: 100vw;
     max-height: 100px;
     margin: 0 auto;
+    top: 90px;
     left: 0;
     right: 0;
     background-color: white;


### PR DESCRIPTION
This PR fixes placing of CategoryTabs on small devices and fixes grid margin-bottom making it smaller because previously it was unnecessary big.